### PR TITLE
Fix CHANGELOG.md template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 * Enhancements
+ * [#3](https://github.com/rapid7/metasploit-version/pull/3) `metasploit-version install` - [@limhoff-r7](https://github.com/limhoff-r7)
 * Bug Fixes
 * Deprecations
 * Incompatible Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
-# Next Release
+# Changelog
+
+## Next Release
 
 * Enhancements
 * Bug Fixes
 * Deprecations
 * Incompatible Changes
+
+## 0.1.2
+
+* Enhancements
+  * [#1](https://github.com/rapid7/metasploit-version/pull/1) "Metasploit::Version GEM_VERSION constant",
+    "Metasploit::Version VERSION constant", and "Metasploit::Version Version Module" shared examples for checking
+    semantic versioning in projects. - [@limhoff-r7](https://github.com/limhoff-r7)
+  * [#2](https://github.com/rapid7/metasploit-version/pull/2) Use of metasploit-yard to ensure full documentation
+    coverage on travis-ci. - [@limhoff-r7](https://github.com/limhoff-r7)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,10 @@ Push your branch to your fork on gitub: `git push TYPE/ISSUE/SUMMARY`
 
 - [ ] `bundle install`
 
+## `rake cucumber`
+- [ ] `rake cucumber`
+- [ ] VERIFY no failures
+
 ## `rake spec`
 - [ ] `rake spec`
 - [ ] VERIFY no failures

--- a/app/templates/CHANGELOG.md.tt
+++ b/app/templates/CHANGELOG.md.tt
@@ -4,15 +4,3 @@
 * Bug Fixes
 * Deprecations
 * Incompatible Changes
-
-# 0.1.2
-
-* Enhancements
-  * [#1](https://github.com/rapid7/metasploit-version/pull/1) "Metasploit::Version GEM_VERSION constant",
-    "Metasploit::Version VERSION constant", and "Metasploit::Version Version Module" shared examples for checking
-    semantic versioning in projects. - [@limhoff-r7](https://github.com/limhoff-r7)
-  * [#2](https://github.com/rapid7/metasploit-version/pull/2) Use of metasploit-yard to ensure full documentation
-    coverage on travis-ci. - [@limhoff-r7](https://github.com/limhoff-r7)
-* Bug Fixes
-* Deprecations
-* Incompatible Changes

--- a/app/templates/CHANGELOG.md.tt
+++ b/app/templates/CHANGELOG.md.tt
@@ -1,4 +1,6 @@
-# Next Release
+# Changelog
+
+## Next Release
 
 * Enhancements
 * Bug Fixes

--- a/features/metasploit-version/install/changelog.feature
+++ b/features/metasploit-version/install/changelog.feature
@@ -18,7 +18,7 @@ Feature: metasploit-version install should add CHANGELOG.md
       | variable            | value |
       | TRAVIS_PULL_REQUEST | false |
     When I successfully run `metasploit-version install --force --no-bundle-install`
-    Then the file "CHANGELOG.md" should contain:
+    Then the file "CHANGELOG.md" should contain exactly:
       """
       # Next Release
 

--- a/features/metasploit-version/install/changelog.feature
+++ b/features/metasploit-version/install/changelog.feature
@@ -26,4 +26,5 @@ Feature: metasploit-version install should add CHANGELOG.md
       * Bug Fixes
       * Deprecations
       * Incompatible Changes
+
       """

--- a/features/metasploit-version/install/changelog.feature
+++ b/features/metasploit-version/install/changelog.feature
@@ -20,7 +20,9 @@ Feature: metasploit-version install should add CHANGELOG.md
     When I successfully run `metasploit-version install --force --no-bundle-install`
     Then the file "CHANGELOG.md" should contain exactly:
       """
-      # Next Release
+      # Changelog
+
+      ## Next Release
 
       * Enhancements
       * Bug Fixes

--- a/lib/metasploit/version/version.rb
+++ b/lib/metasploit/version/version.rb
@@ -12,6 +12,8 @@ module Metasploit
       MINOR = 1
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 3
+      # The prerelease version, scoped to the {PATCH} version number.
+      PRERELEASE = 'changelog-template'
 
       #
       # Module Methods


### PR DESCRIPTION
MSP-11837

It appears that the contents of `CHANGELOG.md` and `app/templates/CHANGELOG.md.tt` got swapped.  The template had the changes from `metasploit-version` itself while `CHANGELOG.md` had just the starting template.  I think this occured because I copied `CHANGELOG.md` to `app/templates/CHANGELOG.md.tt` and then tried running `metasploit-version install` on top of the project itself.

# Verification Steps

## Specs
- [x] `rake spec`
- [x] VERIFY no failues

## Cucumber
- [x] `rake cucumber`
- [x] VERIFY no failures

## CHANGELOG.md template
- [x] `open app/templates/CHANGELOG.md.tt`
- [x] VERIFY `Changelog` header at top of file
- [x] VERIFY releases a higher header number than `Changelog`
- [x] VERIFY there are no actual changes references in the file.

## CHANGELOG.md
- [x] `open CHANGELOG.md`
- [x] VERIFY `Changelog` header at top of file
- [x] VERIFY releases a higher header number than `Changelog`
- [x] VERIFY #3 is in Next Release
- [x] VERIFY #2 and #1 are in 

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/version/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`