### PR TITLE
Make sure Metasploit constant exists before using it

### DIFF
--- a/lib/metasploit/version/version.rb
+++ b/lib/metasploit/version/version.rb
@@ -13,6 +13,8 @@ module Metasploit
       # The patch number, scoped to the {MINOR} version number.
       PATCH = 3
 
+      PRERELEASE = 'metasploit-constant'
+
       #
       # Module Methods
       #

--- a/spec/support/shared/examples/metasploit/version/version_module.rb
+++ b/spec/support/shared/examples/metasploit/version/version_module.rb
@@ -1,3 +1,5 @@
+require 'metasploit/version/branch'
+
 shared_examples_for 'Metasploit::Version Version Module' do
   context 'CONSTANTS' do
     context 'MAJOR' do


### PR DESCRIPTION
# Verification
- [x] get rapid7/smb2#1
  - [x] add `gem 'metasploit-version', path: '/path/to/this/PR/checkout' to its `Gemfile`
  - [x] `rm Gemfile.lock`
  - [x] `bundle`
  - [x] `bundle exec rake`
  - [x] **Verify** it doesn't explode with undefined const exception
  - [x] fix `Gemfile` - `git checkout -- Gemfile`

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit/version/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`
